### PR TITLE
collect more metrics from kube-state-merics,cadvisor and tidb-monitor

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
@@ -69,7 +69,6 @@ spec:
         - --port=8080
         - --telemetry-port=8081
         - --kubeconfig=/etc/kube-state-metrics/config/kubeconfig
-        - --namespace=kube-system
         - --collectors=daemonsets,deployments,nodes,pods,statefulsets
         volumeMounts:
         - name: kubeconfig
@@ -92,8 +91,8 @@ spec:
           timeoutSeconds: 5
         resources:
           requests:
-            cpu: 10m
-            memory: 32Mi
+            cpu: 80m
+            memory: 256Mi
       volumes:
       - name: kubeconfig
         secret:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/shoot-tidb.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/shoot-tidb.rules.yaml
@@ -1,0 +1,69 @@
+groups:
+- name: shoot-tidb.rules
+  rules:
+  - alert: TiDBDown
+    expr: sum(up{exported_job="tidb"})  by (kubernetes_namespace) == 0
+    for: 5m
+    labels:
+      service: shoot-tidb-service
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      description: There are no running TiDB pods for the past last 5 minutes.
+      summary: TiDB is down
+  - alert: AtLeastOneTiDBPodDown
+    expr: sum(up{exported_job="tidb"} != 1) by (kubernetes_namespace) 
+    for: 5m
+    labels:
+      service: shoot-tidb-service
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      description: There is at least one TiDB pod down for the past last 5 minutes.
+      summary: TiDB has dead pod.
+  - alert: TiKVDown
+    expr: sum(up{exported_job="tikv"}) by (kubernetes_namespace) == 0
+    for: 5m
+    labels:
+      service: shoot-tikv-service
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      description: There are no running TiKV pods for the past last 5 minutes.
+      summary: TiKV is down
+  - alert: AtLeastOneTikvPodDown
+    expr: sum(up{exported_job="tikv"} != 1) by (kubernetes_namespace) 
+    for: 5m
+    labels:
+      service: shoot-tikv-service
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      description: There is at least one TiKV pod down for the past last 5 minutes.
+      summary: TiKV has dead pod.
+  - alert: TiDBClusterKeepInitialing
+    expr: sum(kube_pod_status_phase{pod=~"tidb.*-init.*"}) by (namespace) > 0 
+    for: 15m
+    labels:
+      service: shoot-tidb-init
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      description: There is a tidb-init pod for the past last 15 minutes.
+      summary: TiDB Cluster is initialing for 15 minutes
+  - alert: TiDBClusterPendingPods
+    expr: sum(kube_pod_status_phase{namespace=~"tidb.*", phase="Pending"}) by (namespace) > 0
+    for: 10m
+    labels:
+      service: shoot-tidb-pending
+      severity: warning
+      type: shoot
+      visibility: operator
+    annotations:
+      description: There is some pending pods in tidb-about namespace for the past last 5 minutes.
+      summary: Pending pods in TiDB cluster.

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/shoot-tidb.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/shoot-tidb.rules.yaml
@@ -55,7 +55,7 @@ groups:
       visibility: operator
     annotations:
       description: There is a tidb-init pod for the past last 15 minutes.
-      summary: TiDB Cluster is initialing for 15 minutes
+      summary: TiDB Cluster has been initialing for 15 minutes
   - alert: TiDBClusterPendingPods
     expr: sum(kube_pod_status_phase{namespace=~"tidb.*", phase="Pending"}) by (namespace) > 0
     for: 10m
@@ -67,3 +67,14 @@ groups:
     annotations:
       description: There is some pending pods in tidb-about namespace for the past last 5 minutes.
       summary: Pending pods in TiDB cluster.
+  - alert: DBaaSReporterNotRunning
+    expr: absent(up{job="dbaas-reporter"} == 1)
+    for: 5m
+    labels:
+      service: shoot-dbaas-reporter
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      description: There are no running dbaas reporter pods. No data will be reported.
+      summary: DBaaS Reporter is down.

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -98,6 +98,25 @@ data:
         regex: db-prometheus;http-prometheus
         action: keep
 
+    - job_name: 'dbaas-reporter'
+      tls_config:
+        # This is needed because the kubelets' certificates are not are generated
+        # for a specific pod IP
+        insecure_skip_verify: true
+        cert_file: /srv/kubernetes/prometheus-kubelet/prometheus-kubelet.crt
+        key_file: /srv/kubernetes/prometheus-kubelet/prometheus-kubelet.key
+      kubernetes_sd_configs:
+      - role: endpoints
+        api_server: https://kube-apiserver:443
+        tls_config:
+{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels:
+        - __meta_kubernetes_endpoints_name
+        regex: dbaas-reporter
+        action: keep
+
     - job_name: kube-etcd3
       scheme: https
       tls_config:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -110,6 +110,7 @@ data:
         api_server: https://kube-apiserver:443
         tls_config:
 {{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+      relabel_configs:
       - target_label: __metrics_path__
         replacement: /metrics
       - source_labels:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -73,6 +73,31 @@ data:
         regex: true
         action: drop
     scrape_configs:
+    - job_name: tidb-monitor
+      metrics_path: /federate
+      params:
+        'match[]':
+        - '{job="tidb"}'
+        - '{job="tikv"}'
+        - '{job="pd"}'
+      tls_config:
+        # This is needed because the kubelets' certificates are not are generated
+        # for a specific pod IP
+        insecure_skip_verify: true
+        cert_file: /srv/kubernetes/prometheus-kubelet/prometheus-kubelet.crt
+        key_file: /srv/kubernetes/prometheus-kubelet/prometheus-kubelet.key
+      kubernetes_sd_configs:
+      - role: endpoints
+        api_server: https://kube-apiserver:443
+        tls_config:
+{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
+        regex: db-prometheus;http-prometheus
+        action: keep
+
     - job_name: kube-etcd3
       scheme: https
       tls_config:
@@ -220,11 +245,7 @@ data:
         target_label: container
         replacement: '${1}'
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cAdvisor | indent 6 }}
-      # We want to keep only metrics in kube-system namespace
-      - source_labels: [ namespace ]
-        action: keep
-        # systemd containers don't have namespaces
-        regex: (^$|^kube-system$)
+      # Keep metrics in all namespaces
       - source_labels:
         - container
         - __name__
@@ -247,10 +268,10 @@ data:
       static_configs:
       - targets:
         - prometheus-web.garden.svc
-      metric_relabel_configs:
+      # metric_relabel_configs:
       # we make the shoot's pods in the shoot's namespace to appear in as its in the kube-system
-      - target_label: namespace
-        replacement: kube-system
+      # - target_label: namespace
+        # replacement: kube-system
 
     - job_name: kube-state-metrics
       honor_labels: false
@@ -274,8 +295,8 @@ data:
         replacement: kube-state-metrics
       metric_relabel_configs:
       # we make the shoot's pods in the shoot's namepsace to apear in as its in the kube-system
-      - target_label: namespace
-        replacement: kube-system
+      # - target_label: namespace
+        # replacement: kube-system
       - source_labels: [ pod ]
         regex: ^.+\.tf-pod.+$
         action: drop

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -38,8 +38,6 @@ spec:
         env:
         - name: GF_AUTH_BASIC_ENABLED
           value: "false"
-        - name: GF_AUTH_DISABLE_LOGIN_FORM
-          value: "true"
         - name: GF_AUTH_ANONYMOUS_ENABLED
           value: "true"
         - name: GF_SNAPSHOTS_EXTERNAL_ENABLED


### PR DESCRIPTION
Signed-off-by: zhaoyixuan <johnsonqrr@gmail.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area monitoring
/kind enhancement
/priority critical

**What this PR does / why we need it**:
* Make Prometheus scrape advisor data and kubelet data from all namespaces
* Make kube-state-metrics collect data from all namespaces
* Add job to collect tidb-monitor data
* Enable grafana login.
* Disable the config which mapped all namespaces into `kube-system`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
