### PR TITLE
collect all kubelet metrics

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -17,7 +17,7 @@ data:
       evaluation_interval: 1m
       scrape_interval: 1m
       external_labels:
-        cluster: {{ .Release.Namespace }}
+        cluster: shoot/{{ .Values.seed.provider }}/{{ .Values.seed.region }}/{{ .Release.Namespace }}
         project: {{ .Values.shoot.project }}
         shoot_name: {{ .Values.shoot.name }}
         name: {{ .Values.shoot.name }}

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -228,10 +228,10 @@ data:
       - target_label: type
         replacement: shoot
       # get system services
-      metric_relabel_configs:
-      - source_labels: [ __name__ ]
-        regex: ^({{ if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}kubelet_pod_start_latency_microseconds|{{ end }}|kubelet_running_pod_count|process_max_fds|process_open_fds)$
-        action: keep
+      # metric_relabel_configs:
+      # - source_labels: [ __name__ ]
+      #   regex: ^({{ if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}kubelet_pod_start_latency_microseconds|{{ end }}|kubelet_running_pod_count|process_max_fds|process_open_fds)$
+      #   action: keep
 
     - job_name: cadvisor
       honor_labels: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area TODO
/kind TODO
/priority normal

**What this PR does / why we need it**:
gardener only collect partial kubelet metrics, I think we want to more kubelet metrics to add more alerts.
please merge after https://github.com/pingcap/gardener/pull/9

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
