### PR TITLE
Mix-in seed-specific overrides for controllerinstallations

### DIFF
--- a/pkg/gardenlet/apis/config/helper/helpers.go
+++ b/pkg/gardenlet/apis/config/helper/helpers.go
@@ -15,6 +15,8 @@
 package helper
 
 import (
+	"fmt"
+
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 )
 
@@ -25,4 +27,27 @@ func SeedNameFromSeedConfig(seedConfig *config.SeedConfig) string {
 		return ""
 	}
 	return seedConfig.Seed.Name
+}
+
+func GetOverrideHelmValues(conf *config.GardenletConfiguration, compName string) (map[string]interface{}, error) {
+
+	emptyValues := make(map[string]interface{})
+	if conf.OverrideHelmValues == nil {
+		return emptyValues, nil
+	}
+	data := conf.OverrideHelmValues.UnstructuredContent()
+
+	if len(data) == 0 {
+		return emptyValues, nil
+	}
+
+	values, ok := data[compName]
+	if !ok {
+		return emptyValues, nil
+	}
+	overrideValues, ok := values.(map[string]interface{})
+	if !ok {
+		return emptyValues, fmt.Errorf("invalid override helm values in gardenlet config, values: %v", values)
+	}
+	return overrideValues, nil
 }

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/logger"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/utils"
@@ -241,6 +242,14 @@ func (c *defaultControllerInstallationControl) reconcile(controllerInstallation 
 				"spec":            seed.Spec,
 			},
 		},
+	}
+
+	// Mix-in seed-specific overrides
+	override, err := gardenlethelper.GetOverrideHelmValues(c.config, controllerRegistration.Name)
+	if err != nil {
+		logger.Warningf("err get override values for %s, err: %+v", controllerRegistration.Name, err)
+	} else {
+		gardenerValues = utils.MergeMaps(gardenerValues, override)
 	}
 
 	release, err := chartRenderer.RenderArchive(helmDeployment.Chart, controllerRegistration.Name, namespace.Name, utils.MergeMaps(helmDeployment.Values, gardenerValues))

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -453,7 +453,7 @@ func (c *Controller) updateShootStatusReconcileSuccess(o *operation.Operation, o
 		func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
 			shoot.Status.RetryCycleStartTime = nil
 			shoot.Status.SeedName = &o.Seed.Info.Name
-			shoot.Status.InfrastructureProviderStatus =  &runtime.RawExtension{
+			shoot.Status.InfrastructureProviderStatus = &runtime.RawExtension{
 				Raw: o.Shoot.InfrastructureStatus,
 			}
 			shoot.Status.IsHibernated = o.Shoot.HibernationEnabled

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -27,6 +27,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/features"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
@@ -1245,26 +1246,10 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 func (b *Botanist) OverrideHelmValues(name string) map[string]interface{} {
 	log := b.Logger
 
-	emptyValues := make(map[string]interface{})
-	if b.Config.OverrideHelmValues == nil {
-		return emptyValues
+	overrideValues, err := helper.GetOverrideHelmValues(b.Config, name)
+	if err != nil {
+		log.Warnf("err get override helm values, err: %+v", err)
 	}
-	data := b.Config.OverrideHelmValues.UnstructuredContent()
-
-	if len(data) == 0 {
-		return emptyValues
-	}
-
-	values, ok := data[name]
-	if !ok {
-		return emptyValues
-	}
-	overrideValues, ok := values.(map[string]interface{})
-	if !ok {
-		log.Warnf("invalid override helm values in gardenlet config, values: %v", values)
-		return emptyValues
-	}
-	log.Infof("override helm values for component: %s, values: %v", name, overrideValues)
 	return overrideValues
 }
 


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

**What this PR does / why we need it**:
follow up https://github.com/tidbcloud/infra/pull/306, since controllerregistration is global, we need a seed-level override to apply seed-specific configurations.

**Special notes for your reviewer**:

Tested manually:

gardenlet configmap:
```
    overrideHelmValues:
      kind: HelmValues
      etcd:
        serviceAccountAnnotations:
          "eks.amazonaws.com/role-arn": ****
      provider-aws:
        config:
          overrideHelmValues:
            cloud-controller-manager:
              serviceAccountAnnotations:
                eks.amazonaws.com/role-arn: ****
            kind: HelmValues
            machine-controller-manager:
              serviceAccountAnnotations:
                eks.amazonaws.com/role-arn: ****
        serviceAccountAnnotations:
          eks.amazonaws.com/role-arn: ****
      dns-external:
        serviceAccountAnnotations:
          eks.amazonaws.com/role-arn: ****
```

controllers:

```
$ kg sa -n extension-dns-external-gqg94 seed-dns-controller-manager  -o yaml | grep eks
    eks.amazonaws.com/role-arn: arn:aws:iam::385595570414:role/gardener-extension-provider-aws20201202083159647900000001
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
